### PR TITLE
Add astroquery

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ TEST_DEPS = "pytest pytest-remotedata stwcs git+https://github.com/spacetelescop
 
 // Conda needs explicit dependencies listed
 DEPS = "fitsblender graphviz nictools numpydoc matplotlib drizzlepac\
-        pytest pytest-remotedata photutils \
+        pytest pytest-remotedata photutils astroquery\
         scipy sphinx sphinx_rtd_theme \
         stsci_rtd_theme stsci.tools\
         stwcs setuptools python"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ for (numpy_ver in matrix_numpy) {
                         'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
     install.build_cmds = [
         // Install python @ version
-        "${CONDA_CREATE} -n ${python_ver} ${DEPS_PYTHON} stsci-hst",
+        "${CONDA_CREATE} -n ${python_ver} ${DEPS_PYTHON} stsci",
 
         // Install custom required packages @ version
         "${WRAPPER} ${PIP_INST} ${DEPS_EX}",

--- a/hlapipeline/utils/astroquery_utils.py
+++ b/hlapipeline/utils/astroquery_utils.py
@@ -28,7 +28,7 @@ def retrieve_observation(obsid, suffix=['FLC']):
     local_files = []
     obsTable = Observations.query_criteria(obs_id=obsid)
     # Catch the case where no files are found for download
-    if len(obsTable) = 0:
+    if len(obsTable) == 0:
         print("WARNING: Query for {} returned NO RESULTS!".format(obsid))
         return local_files
 

--- a/hlapipeline/utils/astroquery_utils.py
+++ b/hlapipeline/utils/astroquery_utils.py
@@ -28,7 +28,7 @@ def retrieve_observation(obsid, suffix=['FLC']):
     local_files = []
     obsTable = Observations.query_criteria(obs_id=obsid)
     # Catch the case where no files are found for download
-    if len(obsTable) < 0:
+    if len(obsTable) = 0:
         print("WARNING: Query for {} returned NO RESULTS!".format(obsid))
         return local_files
 

--- a/hlapipeline/utils/astroquery_utils.py
+++ b/hlapipeline/utils/astroquery_utils.py
@@ -1,0 +1,57 @@
+"""Wrappers for astroquery-related functionality"""
+import shutil
+import os
+
+from astroquery.mast import Observations
+
+
+def retrieve_observation(obsid, suffix=['FLC']):
+    """Simple interface for retrieving an observation from the MAST archive
+
+    If the input obsid is for an association, it will request all members with
+    the specified suffixes.
+
+    Parameters
+    -----------
+    obsid : string
+        ID for observation to be retrieved from the MAST archive.  Only the
+        IPPSSOOT (rootname) of exposure or ASN needs to be provided; eg., ib6v06060.
+
+    suffix : list
+        List containing suffixes of files which should be requested from MAST.
+
+    path : string
+        Directory to use for writing out downloaded files.  If `None` (default),
+        the current working directory will be used.
+
+    """
+    local_files = []
+    obsTable = Observations.query_criteria(obs_id=obsid)
+    # Catch the case where no files are found for download
+    if len(obsTable) < 0:
+        print("WARNING: Query for {} returned NO RESULTS!".format(obsid))
+        return local_files
+
+    dpobs = Observations.get_product_list(obsTable)
+    dataProductsByID = Observations.filter_products(dpobs,
+                                              productSubGroupDescription=suffix,
+                                              extension='fits',
+                                              mrp_only=False)
+    manifest = Observations.download_products(dataProductsByID, mrp_only=False)
+
+    download_dir = None
+    for file in manifest['Local Path']:
+        # Identify what sub-directory was created by astroquery for the download
+        if download_dir is None:
+            file_path = file.split(os.sep)
+            file_path.remove('.')
+            download_dir = file_path[0]
+        # Move downloaded file to current directory
+        local_file = os.path.abspath(os.path.basename(file))
+        shutil.move(file, local_file)
+        # Record what files were downloaded and their current location
+        local_files.append(local_file)
+    # Remove astroquery created sub-directories
+    shutil.rmtree(download_dir)
+
+    return local_files

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = ['Click>=6.0', 'astropy', 'scipy', 'matplotlib', \
-                'photutils', 'pyyaml', \
+                'photutils', 'pyyaml', 'astroquery',\
                 'scipy', 'sphinx','sphinx_rtd_theme', \
                 'stsci_rtd_theme','stsci.tools',\
                 'stwcs','setuptools']

--- a/tests/base_classes.py
+++ b/tests/base_classes.py
@@ -99,7 +99,7 @@ class BaseTest(object):
             local_files = get_bigdata(*self.get_input_path(),
                                      *args,
                                      docopy=docopy)
-            local_files = list(local_files)
+            local_files = [local_files]
 
         return local_files
 

--- a/tests/base_classes.py
+++ b/tests/base_classes.py
@@ -8,6 +8,8 @@ from astropy.utils.data import conf
 from ci_watson.artifactory_helpers import get_bigdata
 from ci_watson.artifactory_helpers import compare_outputs
 
+from hlapipeline.utils.astroquery_utils import retrieve_observation
+
 # Base classes for actual tests.
 # NOTE: Named in a way so pytest will not pick them up here.
 class BaseTest(object):
@@ -88,14 +90,18 @@ class BaseTest(object):
         `artifactory_helpers/get_bigdata()`.
         This will then return the full path to the local copy of the file.
         """
-        # If user has specified action for no_copy, apply it with
-        # default behavior being whatever was defined in the base class.
-        docopy = kwargs.get('docopy', self.docopy)
-        local_file = get_bigdata(*self.get_input_path(),
-                                 *args,
-                                 docopy=docopy)
+        if len(args[0]) == 9: # Only a rootname provided
+            local_files = retrieve_observation(args[0])
+        else:
+            # If user has specified action for no_copy, apply it with
+            # default behavior being whatever was defined in the base class.
+            docopy = kwargs.get('docopy', self.docopy)
+            local_files = get_bigdata(*self.get_input_path(),
+                                     *args,
+                                     docopy=docopy)
+            local_files = list(local_files)
 
-        return local_file
+        return local_files
 
     def raw_from_asn(self, asn_file):
         """

--- a/tests/base_classes.py
+++ b/tests/base_classes.py
@@ -87,8 +87,15 @@ class BaseTest(object):
     def get_data(self, *args, **kwargs):
         """
         Download `filename` into working directory using
-        `artifactory_helpers/get_bigdata()`.
-        This will then return the full path to the local copy of the file.
+        `artifactory_helpers/get_bigdata()` or 
+        `astroquery_utils.retrieve_observation`.  Use of `astroquery_utils`
+	will allow getting data directly from MAST via astroquery.
+
+        Returns
+        --------
+        local_files : list
+            This will return a list of all the files downloaded with 
+            the full path to the local copy of the file.
         """
         if len(args[0]) == 9: # Only a rootname provided
             local_files = retrieve_observation(args[0])

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -69,26 +69,27 @@ class BaseHLATest(BaseTest):
 #        The associated CRDS reference files in ``refstr`` are also
 #        downloaded, if necessary.
 
-        filename = self.get_data(*args, docopy=docopy)
-        ref_files = ref_from_image(filename, reffile_lookup=self.reffile_lookup)
-        print("Looking for REF_FILES: {}".format(ref_files))
+        filenames = self.get_data(*args, docopy=docopy)
+        for filename in filenames:
+            ref_files = ref_from_image(filename, reffile_lookup=self.reffile_lookup)
+            print("Looking for REF_FILES: {}".format(ref_files))
 
-        for ref_file in ref_files:
-            if ref_file.strip() == '':
-                continue
-            if refsep not in ref_file:  # Local file
-                self.get_data('customRef', ref_file, docopy=docopy)
-            else:
-                # Start by checking to see whether IRAF variable *ref/*tab
-                # has been added to os.environ
-                refdir, refname = ref_file.split(refsep)
-                if refdir not in os.environ or os.environ[refdir] != self.curdir+os.sep:
-                    os.environ[refdir] = self.curdir + os.sep
+            for ref_file in ref_files:
+                if ref_file.strip() == '':
+                    continue
+                if refsep not in ref_file:  # Local file
+                    self.get_data('customRef', ref_file, docopy=docopy)
+                else:
+                    # Start by checking to see whether IRAF variable *ref/*tab
+                    # has been added to os.environ
+                    refdir, refname = ref_file.split(refsep)
+                    if refdir not in os.environ or os.environ[refdir] != self.curdir+os.sep:
+                        os.environ[refdir] = self.curdir + os.sep
 
-                # Download from FTP, if applicable
-                if self.use_ftp_crds and refname not in os.listdir(self.curdir):
-                    download_crds(ref_file, timeout=self.timeout)
-        return filename
+                    # Download from FTP, if applicable
+                    if self.use_ftp_crds and refname not in os.listdir(self.curdir):
+                        download_crds(ref_file, timeout=self.timeout)
+        return filenames
 
 """
 class BaseACSHRC(BaseACS):

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -89,3 +89,21 @@ class TestAlignMosaic(BaseHLATest):
         rms_y = max(shift_file['col7'])
 
         assert (rms_x <= 0.25 and rms_y <= 0.25)
+
+    def test_astroquery(self):
+        """Verify that new astroquery interface will work"""
+        self.curdir = os.getcwd()
+        self.input_loc = ''
+
+        filenames = self.get_input_file('ib6v06060')
+        for infile in filenames:
+            updatewcs.updatewcs(infile)
+
+        output_shift_file = 'test_astroquery_shifts.txt'
+        align_to_gaia.align(filenames, shift_name=output_shift_file)
+
+        shift_file = Table.read(output_shift_file, format='ascii')
+        rms_x = max(shift_file['col6'])
+        rms_y = max(shift_file['col7'])
+
+        assert (rms_x <= 0.25 and rms_y <= 0.25)


### PR DESCRIPTION
This PR adds all the functionality necessary to use astroquery in the HLAPipeline for getting specific datasets.  The stand-alone functionality was then incorporated into the test classes to transparently handle getting data from astroquery as well as Artifactory or the local cache.  

A new test was also added to specifically test/demonstrate this new functionality. 