### PR TITLE
Fix logic for downloading ref files

### DIFF
--- a/hlapipeline/align_to_gaia.py
+++ b/hlapipeline/align_to_gaia.py
@@ -23,7 +23,7 @@ def align(expnames, **kwargs):
     shift_name = kwargs.get('shift_name',None)
     if shift_name is None:
         shift_name = 'shifts_gaia.txt'
-    ref_cat_file = kwargs.get('output', None)
+    ref_cat_file = kwargs.get('ref_cat_file', 'gaia_ref.cat')
     # Set default values for specific Tweakreg parameters which are more
     # appropriate for most of our use cases
     updatehdr = kwargs.get('updatehdr', False)

--- a/hlapipeline/align_to_gaia.py
+++ b/hlapipeline/align_to_gaia.py
@@ -20,10 +20,11 @@ def align(expnames, **kwargs):
         Filename of shift file written out by `tweakreg.Tweakreg`
 
     """
+    setname = os.path.basename(expnames[0]).split('_')[0]
     shift_name = kwargs.get('shift_name',None)
     if shift_name is None:
-        shift_name = 'shifts_gaia.txt'
-    ref_cat_file = kwargs.get('ref_cat_file', 'gaia_ref.cat')
+        shift_name = '{}_shifts_gaia.txt'.format(setname)
+    ref_cat_file = kwargs.get('ref_cat_file', '{}_gaia_ref.cat'.format(setname))
     # Set default values for specific Tweakreg parameters which are more
     # appropriate for most of our use cases
     updatehdr = kwargs.get('updatehdr', False)

--- a/hlapipeline/align_to_gaia.py
+++ b/hlapipeline/align_to_gaia.py
@@ -1,3 +1,4 @@
+import os
 import hlapipeline.utils.astrometric_utils as hlautils
 
 from drizzlepac import tweakreg
@@ -33,7 +34,8 @@ def align(expnames, **kwargs):
     conv_width = kwargs.get('conv_width', 3.5)
 
     gaia_catalog = hlautils.create_astrometric_catalog(expnames, **kwargs)
-    gaia_catalog.write(ref_cat_file, format='ascii.no_header')
+    gaia_catalog.write(ref_cat_file, format='ascii.no_header', overwrite=True)
+    print("FINISHED writing out gaia_catalog: {}".format(os.path.abspath(ref_cat_file)))
 
     if len(gaia_catalog) > 6:
         fitgeometry = 'general'

--- a/hlapipeline/utils/astrometric_utils.py
+++ b/hlapipeline/utils/astrometric_utils.py
@@ -72,7 +72,7 @@ def create_astrometric_catalog(inputs, **pars):
     output : str, optional
         Filename to give to the astrometric catalog read in from the master
         catalog web service.  If 'None', no file will be written out.
-        Default: ref.cat
+        Default: ref_cat.ecsv
 
     gaia_only : bool, optional
         Specify whether or not to only use sources from GAIA in output catalog

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -89,11 +89,11 @@ class BaseHLATest(BaseTest):
                     # Start by checking to see whether IRAF variable *ref/*tab
                     # has been added to os.environ
                     refdir, refname = ref_file.split(refsep)
-                    if refdir not in os.environ or os.environ[refdir] != self.curdir+os.sep:
+                    if refdir not in os.environ: 
                         os.environ[refdir] = self.curdir + os.sep
 
                     # Download from FTP, if applicable
-                    if self.use_ftp_crds and refname not in os.listdir(self.curdir):
+                    if self.use_ftp_crds: 
                         download_crds(ref_file, timeout=self.timeout)
         return filenames
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -74,11 +74,11 @@ class BaseHLATest(BaseTest):
 #        Download or copy input file (e.g., RAW) into the working directory.
 #        The associated CRDS reference files in ``refstr`` are also
 #        downloaded, if necessary.
-
+        curdir = os.getcwd()
         filenames = self.get_data(*args, docopy=docopy)
         for filename in filenames:
             ref_files = ref_from_image(filename, reffile_lookup=self.reffile_lookup)
-            print("Looking for REF_FILES: {}".format(ref_files))
+            print("Looking for {} REF_FILES: {}".format(filename, ref_files))
 
             for ref_file in ref_files:
                 if ref_file.strip() == '':
@@ -89,11 +89,17 @@ class BaseHLATest(BaseTest):
                     # Start by checking to see whether IRAF variable *ref/*tab
                     # has been added to os.environ
                     refdir, refname = ref_file.split(refsep)
-                    if refdir not in os.environ: 
-                        os.environ[refdir] = self.curdir + os.sep
+                    refdir_parent = os.path.split(refdir)[0]
+                    # Define refdir to point to current directory if:
+                    #   i. refdir is not defined in environment already
+                    #  ii. refdir in os.environ points to another test directory
+                    # This logic should leave refdir unchanged if it already
+                    # points to a globally defined directory.
+                    if refdir not in os.environ or refdir_parent in curdir:
+                        os.environ[refdir] = curdir + os.sep
 
                     # Download from FTP, if applicable
-                    if self.use_ftp_crds: 
+                    if self.use_ftp_crds:
                         download_crds(ref_file, timeout=self.timeout)
         return filenames
 


### PR DESCRIPTION
This resolves logic problems with 'get_input_file' where reference files were being downloaded to the local test directory when they were still readable from a local cache on central store based on definitions of 'jref' and other IRAF variables.  The problem resulted in Mike not being able to run the tests on his new installation.

The logic is now changed to not duplicate logic that is already implemented in ci_watson about deciding what to download.