### PR TITLE
Update run_align method, add test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ PYTEST = "pytest --basetemp=tests_output --junitxml results.xml --bigdata"
 
 // The minimum modules required to execute setup.py at all
 BASE_DEPS = "astropy numpy pyyaml"
-TEST_DEPS = "pytest pytest-remotedata stwcs git+https://github.com/spacetelescope/ci_watson.git@master"
+TEST_DEPS = "pytest=3.8.2 pytest-remotedata stwcs git+https://github.com/spacetelescope/ci_watson.git@master"
 
 // Conda needs explicit dependencies listed
 DEPS = "fitsblender graphviz nictools numpydoc matplotlib drizzlepac\

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ PYTEST = "pytest --basetemp=tests_output --junitxml results.xml --bigdata"
 
 // The minimum modules required to execute setup.py at all
 BASE_DEPS = "astropy numpy pyyaml"
-TEST_DEPS = "pytest=3.8.2 pytest-remotedata stwcs git+https://github.com/spacetelescope/ci_watson.git@master"
+TEST_DEPS = "pytest==3.8.2 pytest-remotedata stwcs git+https://github.com/spacetelescope/ci_watson.git@master"
 
 // Conda needs explicit dependencies listed
 DEPS = "fitsblender graphviz nictools numpydoc matplotlib drizzlepac\

--- a/hlapipeline/align_to_gaia.py
+++ b/hlapipeline/align_to_gaia.py
@@ -10,8 +10,18 @@ def align(expnames, **kwargs):
     expnames : str or list of strings
         Filename of exposure or list of filenames to be aligned to GAIA catalog
 
+    Returns
+    =======
+    gaia_catalog : Table
+        Astropy Table object containing gaia catalog retrieved for exposures
+
+    shift_name : string
+        Filename of shift file written out by `tweakreg.Tweakreg`
+
     """
-    shift_name = kwargs.get('shift_name','shifts_gaia.txt')
+    shift_name = kwargs.get('shift_name',None)
+    if shift_name is None:
+        shift_name = 'shifts_gaia.txt'
     ref_cat_file = kwargs.get('output', None)
     # Set default values for specific Tweakreg parameters which are more
     # appropriate for most of our use cases
@@ -45,4 +55,4 @@ def align(expnames, **kwargs):
                       searchrad=searchrad,
                       searchunits=searchunits,
                       fitgeometry=fitgeometry)
-    return gaia_catalog
+    return gaia_catalog, shift_name

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -98,15 +98,22 @@ class BaseHLATest(BaseTest):
         return filenames
 
     def run_align(self, input_filenames):
+
+        # protect against getting a single exposure filename or rootname as input
+        if not isinstance(input_filenames, list):
+            input_filenames = [input_filenames]
+
         self.curdir = os.getcwd()
 
+        all_files = []
         for infile in input_filenames:
-            self.get_input_file(infile, docopy=True)
-            updatewcs.updatewcs(infile)
+            downloaded_files = self.get_input_file(infile, docopy=True)
+            updatewcs.updatewcs(downloaded_files)
+            all_files.extend(downloaded_files)
 
-        align_to_gaia.align(input_filenames, shift_name=self.output_shift_file)
+        gaia_catalog, shift_file_name = align_to_gaia.align(all_files, shift_name=self.output_shift_file)
 
-        shift_file = Table.read(self.output_shift_file, format='ascii')
+        shift_file = Table.read(shift_file_name, format='ascii')
         return shift_file
 
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -81,14 +81,7 @@ class TestAlignMosaic(BaseHLATest):
         self.curdir = os.getcwd()
         self.input_loc = ''
 
-        filenames = self.get_input_file('ib6v06060')
-        for infile in filenames:
-            updatewcs.updatewcs(infile)
-
-        output_shift_file = 'test_astroquery_shifts.txt'
-        align_to_gaia.align(filenames, shift_name=output_shift_file)
-
-        shift_file = Table.read(output_shift_file, format='ascii')
+        shift_file = self.run_align('ib6v06060')
         rms_x = max(shift_file['col6'])
         rms_y = max(shift_file['col7'])
 


### PR DESCRIPTION
Changes made here address issue #12 and include:
- Revise `run_align()` method to correctly pass filenames from one operation to another
- Modify `align_to_gaia.align()` function to also pass back filename of shift file written out by Tweakreg.  This will allow calling code to NOT set shift_file_name and still have a unique shift file written out.
- Revise `test_astroquery` test in `test_align` to exercise the error case of passing in a single rootname to 'run_align` which was the cause of the problems in issue #12 .
- The doc string for `align_to_gaia.align()` was also updated to reflect the return values.

 