### PR TITLE
Add obstype specification to MAST query

### DIFF
--- a/hlapipeline/utils/astroquery_utils.py
+++ b/hlapipeline/utils/astroquery_utils.py
@@ -26,7 +26,7 @@ def retrieve_observation(obsid, suffix=['FLC']):
 
     """
     local_files = []
-    obsTable = Observations.query_criteria(obs_id=obsid)
+    obsTable = Observations.query_criteria(obs_id=obsid, obstype='all')
     # Catch the case where no files are found for download
     if len(obsTable) == 0:
         print("WARNING: Query for {} returned NO RESULTS!".format(obsid))


### PR DESCRIPTION
Fixes Git Issue #20.

Added the `obstype='all'` to the astroquery Observations.query_criteria() in order to enable queries which are classified as calibration, as well as science, in MAST.  While the classification may be calibration, the images are actually science fields (versus dark image as an example).