### PR TITLE
Update limit to be detector specific, use GAIADR2

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -121,7 +121,7 @@ class BaseHLATest(BaseTest):
         gaia_catalog, shift_file_name = align_to_gaia.align(all_files, shift_name=self.output_shift_file)
 
         shift_file = Table.read(shift_file_name, format='ascii')
-        return shift_file
+        return shift_file, all_files
 
 
 """

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -30,7 +30,8 @@ class BaseHLATest(BaseTest):
     input_repo = 'hst-hla-pipeline'
     results_root = 'hst-hla-pipeline-results'
     output_shift_file = None
-
+    fit_limit = 0.010 # 10 milli-arcseconds
+    
     docopy = False  # Do not make additional copy by default
     rtol = 1e-6
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -11,6 +11,7 @@ from stwcs import updatewcs
 from base_test import BaseHLATest
 from hlapipeline import align_to_gaia
 import hlapipeline.utils.catalog_utils as catutils
+import hlapipeline.utils.astrometric_utils as amutils
 
 @pytest.mark.bigdata
 class TestAlignMosaic(BaseHLATest):
@@ -59,7 +60,9 @@ class TestAlignMosaic(BaseHLATest):
         rms_x = max(shift_file['col6'])
         rms_y = max(shift_file['col7'])
 
-        assert (rms_x <= 0.25 and rms_y <= 0.25)
+        reference_wcs = amutils.build_reference_wcs(input_filenames)
+        test_limit = self.fit_limit / reference_wcs.pscale
+        assert (rms_x <= test_limit and rms_y <= test_limit)
 
     def test_align_47tuc(self):
         """ Verify whether 47Tuc exposures can be aligned to an astrometric standard.
@@ -79,7 +82,9 @@ class TestAlignMosaic(BaseHLATest):
         rms_x = max(shift_file['col6'])
         rms_y = max(shift_file['col7'])
 
-        assert (rms_x <= 0.25 and rms_y <= 0.25)
+        reference_wcs = amutils.build_reference_wcs(input_filenames)
+        test_limit = self.fit_limit / reference_wcs.pscale
+        assert (rms_x <= test_limit and rms_y <= test_limit)
 
     @pytest.mark.xfail
     @pytest.mark.parametrize("input_filenames", [['j8ura1j1q_flt.fits','j8ura1j2q_flt.fits',
@@ -144,7 +149,10 @@ class TestAlignMosaic(BaseHLATest):
             exc_type, exc_value, exc_tb = sys.exc_info()
             traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
             sys.exit()
-        assert (x_shift == False and y_shift == False and rms_x <= 0.25 and rms_y <= 0.25)
+
+        reference_wcs = amutils.build_reference_wcs(input_filenames)
+        test_limit = self.fit_limit / reference_wcs.pscale
+        assert (x_shift == False and y_shift == False and rms_x <= test_limit and rms_y <= test_limit)
 
     def test_astroquery(self):
         """Verify that new astroquery interface will work"""
@@ -155,7 +163,9 @@ class TestAlignMosaic(BaseHLATest):
         rms_x = max(shift_file['col6'])
         rms_y = max(shift_file['col7'])
 
-        assert (rms_x <= 0.25 and rms_y <= 0.25)
+        reference_wcs = amutils.build_reference_wcs(input_filenames)
+        test_limit = self.fit_limit / reference_wcs.pscale
+        assert (rms_x <= test_limit and rms_y <= test_limit)
 
     @pytest.mark.xfail
     @pytest.mark.slow

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -4,7 +4,6 @@ import os
 import datetime
 import pytest
 import numpy
-import glob
 from astropy.table import Table
 
 from stwcs import updatewcs
@@ -56,12 +55,12 @@ class TestAlignMosaic(BaseHLATest):
                             'j8boa1m8q_flc.fits', 'j8boa1m4q_flc.fits',
                             'j8boa1maq_flc.fits', 'j8boa1m6q_flc.fits']
         self.output_shift_file = 'test_mosaic_ngc188_shifts.txt'
-        shift_file = self.run_align(input_filenames)
+        shift_file, local_files = self.run_align(input_filenames)
 
         rms_x = max(shift_file['col6'])
         rms_y = max(shift_file['col7'])
 
-        reference_wcs = amutils.build_reference_wcs(input_filenames)
+        reference_wcs = amutils.build_reference_wcs(local_files)
         test_limit = self.fit_limit / reference_wcs.pscale
         assert (rms_x <= test_limit and rms_y <= test_limit)
 
@@ -78,12 +77,12 @@ class TestAlignMosaic(BaseHLATest):
                                 'jddh02gjq_flc.fits','jddh02glq_flc.fits',
                                 'jddh02goq_flc.fits']
         self.output_shift_file = 'test_mosaic_47tuc_shifts.txt'
-        shift_file = self.run_align(input_filenames)
+        shift_file, local_files = self.run_align(input_filenames)
 
         rms_x = max(shift_file['col6'])
         rms_y = max(shift_file['col7'])
 
-        reference_wcs = amutils.build_reference_wcs(input_filenames)
+        reference_wcs = amutils.build_reference_wcs(local_files)
         test_limit = self.fit_limit / reference_wcs.pscale
         assert (rms_x <= test_limit and rms_y <= test_limit)
 
@@ -141,7 +140,7 @@ class TestAlignMosaic(BaseHLATest):
         self.input_loc = 'base_tests'
         self.curdir = os.getcwd()
         try:
-            shift_file = self.run_align(input_filenames)
+            shift_file, local_files = self.run_align(input_filenames)
             x_shift = numpy.alltrue(numpy.isnan(shift_file['col2']))
             y_shift = numpy.alltrue(numpy.isnan(shift_file['col3']))
             rms_x = max(shift_file['col6'])
@@ -151,7 +150,7 @@ class TestAlignMosaic(BaseHLATest):
             traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
             sys.exit()
 
-        reference_wcs = amutils.build_reference_wcs(input_filenames)
+        reference_wcs = amutils.build_reference_wcs(local_files)
         test_limit = self.fit_limit / reference_wcs.pscale
         assert (x_shift == False and y_shift == False and rms_x <= test_limit and rms_y <= test_limit)
 
@@ -160,12 +159,11 @@ class TestAlignMosaic(BaseHLATest):
         self.curdir = os.getcwd()
         self.input_loc = ''
 
-        shift_file = self.run_align('ib6v06060')
-        input_filenames = sorted(glob.glob('ib6v*fl*.fits'))
+        shift_file, local_files = self.run_align('ib6v06060')
         rms_x = max(shift_file['col6'])
         rms_y = max(shift_file['col7'])
 
-        reference_wcs = amutils.build_reference_wcs(input_filenames)
+        reference_wcs = amutils.build_reference_wcs(local_files)
         test_limit = self.fit_limit / reference_wcs.pscale
         assert (rms_x <= test_limit and rms_y <= test_limit)
 
@@ -279,12 +277,15 @@ class TestAlignMosaic(BaseHLATest):
            currentDT = datetime.datetime.now()
            print(str(currentDT))
            try:
-               shift_file = self.run_align([dataset])
+               shift_file, local_files = self.run_align([dataset])
                x_shift = numpy.alltrue(numpy.isnan(shift_file['col2']))
                rms_x = max(shift_file['col6'])
                rms_y = max(shift_file['col7'])
 
-               if not x_shift and ((rms_x <= 0.25) and (rms_y <= 0.25)):
+               reference_wcs = amutils.build_reference_wcs(local_files)
+               test_limit = self.fit_limit / reference_wcs.pscale
+
+               if not x_shift and ((rms_x <= test_limit) and (rms_y <= test_limit)):
                    numSuccess += 1
                    print("TEST_ALIGN. Successful Dataset: ", dataset, "\n")
                else:

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -163,7 +163,7 @@ class TestAlignMosaic(BaseHLATest):
         rms_x = max(shift_file['col6'])
         rms_y = max(shift_file['col7'])
 
-        reference_wcs = amutils.build_reference_wcs(input_filenames)
+        reference_wcs = amutils.build_reference_wcs(['ib6v06060'])
         test_limit = self.fit_limit / reference_wcs.pscale
         assert (rms_x <= test_limit and rms_y <= test_limit)
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -4,6 +4,7 @@ import os
 import datetime
 import pytest
 import numpy
+import glob
 from astropy.table import Table
 
 from stwcs import updatewcs
@@ -160,10 +161,11 @@ class TestAlignMosaic(BaseHLATest):
         self.input_loc = ''
 
         shift_file = self.run_align('ib6v06060')
+        input_filenames = sorted(glob.glob('ib6v*fl*.fits'))
         rms_x = max(shift_file['col6'])
         rms_y = max(shift_file['col7'])
 
-        reference_wcs = amutils.build_reference_wcs(['ib6v06060'])
+        reference_wcs = amutils.build_reference_wcs(input_filenames)
         test_limit = self.fit_limit / reference_wcs.pscale
         assert (rms_x <= test_limit and rms_y <= test_limit)
 


### PR DESCRIPTION
The original test definitions simply made a comparison to 0.25 pixels for the overall RMS of the fit to the astrometric source catalog positions.  However, that results in 10 milli-arcsecond RMS only for WFC3/UVIS data.  The difference in pixel-scale for the other detectors results in different absolute limits being applied, and most are more stringent and therefore, not what has been established as the recognized criteria for success.  

The code change here computes the pixel-scale used for the alignment, and sets the RMS limit based on that to meet the absolute limit of 10 milli-arcseconds RMS to address the problems identified in [JIRA ticket HLA-104](https://jira.stsci.edu/browse/HLA-104). 
  
@mdlpstsci : The tests were also updated to rely on astrometric source positions derived from the **GAIADR2** catalog, instead of the original default of **GSC241**.  This will workaround the problems identified in [JIRA ticket HLA-83](https://jira.stsci.edu/browse/HLA-83) and [JIRA ticket HLA-102](https://jira.stsci.edu/browse/HLA-102).
