### PR TITLE
Add catalog tests

### DIFF
--- a/hlapipeline/utils/astrometric_utils.py
+++ b/hlapipeline/utils/astrometric_utils.py
@@ -162,9 +162,13 @@ def create_astrometric_catalog(inputs, **pars):
 
     # perform query for this field-of-view
     ref_dict = get_catalog(ra, dec, sr=radius, catalog=catalog)
-    colnames = ('RA','DEC', 'mag', 'objID', 'GaiaID')
+    colnames = ('ra','dec', 'mag', 'objID', 'GaiaID')
     col_types = ('f8', 'f8', 'f4', 'U25', 'U25')
     ref_table = Table(names = colnames, dtype=col_types)
+
+    # rename coordinate columns to be consistent with tweakwcs
+    ref_table.rename_column('ra', 'RA')
+    ref_table.rename_column('dec', 'DEC')
 
     # extract just the columns we want...
     num_sources = 0
@@ -175,8 +179,8 @@ def create_astrometric_catalog(inputs, **pars):
                 continue
         else:
             g = -1  # indicator for no source ID extracted
-        r = float(source['RA'])
-        d = float(source['DEC'])
+        r = float(source['ra'])
+        d = float(source['dec'])
         m = float(source['mag'])
         o = source['objID']
         num_sources += 1

--- a/hlapipeline/utils/astrometric_utils.py
+++ b/hlapipeline/utils/astrometric_utils.py
@@ -436,93 +436,6 @@ def classify_sources(catalog, sources=None):
 
     return srctype
 
-def build_source_catalog(image, refwcs, **kwargs):
-    """Build source catalog from input image using photutils.
-
-    The catalog returned by this function includes sources found in all chips
-    of the input image with the positions translated to the coordinate frame
-    defined by the reference WCS `refwcs`.  The sources will be
-      - identified using photutils segmentation-based source finding code
-      - ignore any input pixel which has been flagged as 'bad' in the DQ
-        array, should a DQ array be found in the input HDUList.
-      - classified as probable cosmic-rays (if enabled) using central_moments
-        properties of each source, with these sources being removed from the
-        catalog.
-
-    Parameters
-    -----------
-    image : HDUList object
-        Input image as an astropy.io.fits HDUList object
-
-    refwcs : HSTWCS object
-        Definition of the reference frame WCS.
-
-    dqname : string
-        EXTNAME for the DQ array, if present, in the input image HDUList.
-
-    output : boolean
-        Specify whether or not to write out a separate catalog file for all the
-        sources found in each chip.  Default: None (False)
-
-    threshold : float, optional
-        This parameter controls the S/N threshold used for identifying sources in
-        the image relative to the background RMS in much the same way that
-        the 'threshold' parameter in 'tweakreg' works.
-        Default: 1000.
-
-    fwhm : float, optional
-        FWHM (in pixels) of the expected sources from the image, comparable to the
-        'conv_width' parameter from 'tweakreg'.  Objects with FWHM closest to
-        this value will be identified as sources in the catalog. Default: 3.0.
-
-    Returns
-    --------
-    master_cat : astropy.Table object
-        Source catalog for all 'valid' sources identified from all chips of the
-        input image with positions translated to the reference WCS coordinate
-        frame.
-
-
-    """
-    dqname = kwargs.get('dqname','DQ')
-    output = kwargs.get('output',None)
-    # Build source catalog for entire image
-    master_cat = None
-    numSci = countExtn(image, extname='SCI')
-    # if no refwcs specified, build one now...
-    if refwcs is None:
-        refwcs = build_reference_wcs([image])
-
-    for chip in range(numSci):
-        chip += 1
-        # find sources in image
-        if output:
-            rootname = image[0].header['rootname']
-            outroot = '{}_sci{}_src'.format(rootname, chip)
-            kwargs['output'] = outroot
-        imgarr = image['sci',chip].data
-        photmode = image['sci',chip].header['photmode']
-        # apply any DQ array, if available
-        if image.index_of(dqname):
-            dqarr = image[dqname,chip].data
-            dqmask = bitmask.bitfield_to_boolean_mask(dqarr, good_mask_value=False)
-            imgarr[dqmask] = 0. # zero-out all pixels flagged as bad
-        seg_tab, segmap = extract_sources(imgarr, **kwargs)
-        seg_tab_phot = compute_photometry(seg_tab,photmode)
-        # Convert to sky coordinates
-        chip_wcs = wcsutil.HSTWCS(image,ext=('sci',chip))
-        seg_ra,seg_dec = chip_wcs.all_pix2world(seg_tab_phot['xcentroid'],seg_tab_phot['ycentroid'],1)
-        # Convert sky positions to pixel positions in the reference WCS frame
-        seg_xy_out = refwcs.all_world2pix(seg_ra,seg_dec,1)
-        seg_tab_phot['xcentroid'] = seg_xy_out[0]
-        seg_tab_phot['ycentroid'] = seg_xy_out[1]
-        if master_cat is None:
-            master_cat = seg_tab_phot
-        else:
-            master_cat = vstack([master_cat, seg_tab_phot])
-
-    return master_cat
-
 def generate_source_catalog(image, refwcs, **kwargs):
     """Build source catalog from input image using photutils.
 
@@ -589,7 +502,12 @@ def generate_source_catalog(image, refwcs, **kwargs):
             outroot = '{}_sci{}_src'.format(rootname, chip)
             kwargs['output'] = outroot
         imgarr = image['sci',chip].data
-        photmode = image['sci',chip].header['photmode']
+
+        if 'photmode' in image[0].header:
+            photmode = image[0].header['photmode']
+        else:
+            photmode = image['sci',chip].header['photmode']
+
         # apply any DQ array, if available
         if image.index_of(dqname):
             dqarr = image[dqname,chip].data
@@ -959,7 +877,7 @@ def find_hist2d_offset(filename, reference,  refwcs = None, refnames=['ra', 'dec
     ref_dec = refcat[refnames[1]]
 
     # Build source catalog for entire image
-    img_cat = build_source_catalog(image, refwcs, output=chip_catalog, classify=classify)
+    img_cat = generate_source_catalog(image, refwcs, output=chip_catalog, classify=classify)
     img_cat.write(filename.replace(".fits","_xy.cat"), format='ascii.no_header',
                     overwrite=True)
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -39,7 +39,8 @@ class TestPipeline(BaseHLATest):
 
     @pytest.mark.parametrize("input_filenames, truth_file",
                                 [('j8ep04lwq','j8ep04lwq_sky.cat'),
-                                 ('J8D806010','j8d806bgq_sky_cat.ecsv')]
+                                 ('J8D806010','j8d806bgq_sky_cat.ecsv'),
+                                 ('IB2V09010', 'ib2v09kzq_sky_cat.ecsv')]
                             )
     def test_generate_catalog(self,input_filenames, truth_file):
         """ Verify whether sources from astrometric catalogs can be extracted from images.

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -26,13 +26,15 @@ class TestPipeline(BaseHLATest):
           * The WCS information for the input exposures do not get updated in this test.
           * No mosaic gets generated.
 
-        Success Criteria:
-          * Success criteria for source extraction tests
-            * Initially, source catalog matches >80% of 'truth' catalog sources
             * For observations with >3 astrometric sources, at least 3 sources
             * For observations with 3 or fewer sources, all astrometric sources
               were identified in the image
 
+        The following datasets are used in these tests:
+
+            * j8ep04lwq : ACS/SBC dataset with >10 sources (in image and in GAIADR2)
+            * J8D806010 : ACS/WFC dataset dominated by CRs and 15 GAIA sources
+            * IB2V09010 : WFC3/IR dataset with 24 GAIA sources in field-of-view
     """
 
     ref_loc = ['truth']
@@ -45,9 +47,9 @@ class TestPipeline(BaseHLATest):
     def test_generate_catalog(self,input_filenames, truth_file):
         """ Verify whether sources from astrometric catalogs can be extracted from images.
 
-        The following datasets are used in these tests:
-
-            * ACS/SBC dataset with >10 sources (in image and in GAIADR2)
+        Success Criteria
+        -----------------
+            * Initially, source catalog matches >80% of 'truth' catalog sources
 
         """
         self.input_loc = 'catalog_tests'

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -28,6 +28,7 @@ class TestPipeline(BaseHLATest):
 
         Success Criteria:
           * Success criteria for source extraction tests
+            * Initially, source catalog matches >80% of 'truth' catalog sources
             * For observations with >3 astrometric sources, at least 3 sources
             * For observations with 3 or fewer sources, all astrometric sources
               were identified in the image
@@ -37,7 +38,8 @@ class TestPipeline(BaseHLATest):
     ref_loc = ['truth']
 
     @pytest.mark.parametrize("input_filenames, truth_file",
-                                [('j8ep04lwq','j8ep04lwq_sky.cat')]
+                                [('j8ep04lwq','j8ep04lwq_sky.cat'),
+                                 ('J8D806010','j8d806bgq_sky_cat.ecsv')]
                             )
     def test_generate_catalog(self,input_filenames, truth_file):
         """ Verify whether sources from astrometric catalogs can be extracted from images.
@@ -66,13 +68,17 @@ class TestPipeline(BaseHLATest):
             imcat = input_catalog_dict[local_files[0]]['catalog_table']
             imcat.rename_column('xcentroid', 'x')
             imcat.rename_column('ycentroid', 'y')
-            
+
             # create FITS WCS corrector object
             wcs_corrector = tweakwcs.FITSWCS(reference_wcs)
 
             # get reference catalog as 'truth' files
             reference_catalog = get_bigdata(*truth_path, truth_file, docopy=True)
-            reference_table = Table.read(reference_catalog, format='ascii.fast_commented_header')
+            if os.path.basename(reference_catalog).endswith('ecsv'):
+                tab_format = 'ascii.ecsv'
+            else:
+                tab_format = 'ascii.fast_commented_header'
+            reference_table = Table.read(reference_catalog, format=tab_format)
             num_expected = len(reference_table)
 
             # Perform matching

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,89 @@
+import sys
+import traceback
+import os
+import datetime
+import pytest
+import numpy
+from astropy.table import Table
+
+import tweakwcs
+from base_test import BaseHLATest
+import hlapipeline.utils.catalog_utils as catutils
+import hlapipeline.utils.astrometric_utils as amutils
+#from hlapipeline.alignimages import generate_source_catalogs
+from hlapipeline.utils.astrometric_utils import generate_source_catalogs
+from ci_watson.artifactory_helpers import get_bigdata, compare_outputs
+
+
+class TestPipeline(BaseHLATest):
+    """ Tests which validate whether pipeline code will meet requirements.
+
+        Characeteristics of these tests:
+          * A single astrometric catalog was obtained with both GAIA and non-GAIA
+            (PanSTARRS?) sources for the entire combined field-of-view using the GSSS
+            server.
+          * This test only determines whether enough sources
+            extracted from the images can match the objects included in
+            the astrometric catalog.
+          * Tests are included to cover most observation modes
+            (ACS/SBC, WFC3/IR,...)
+          * The WCS information for the input exposures do not get updated in this test.
+          * No mosaic gets generated.
+
+        Success Criteria:
+          * Success criteria for source extraction tests
+            * For observations with >3 astrometric sources, at least 3 sources
+            * For observations with 3 or fewer sources, all astrometric sources
+              were identified in the image
+
+    """
+
+    ref_loc = ['truth']
+
+    @pytest.mark.parametrize("input_filenames, truth_file",
+                                [('j8ep04lwq','j8ep04lwq_sky.cat')]
+                            )
+    def test_generate_catalog(self,input_filenames, truth_file):
+        """ Verify whether sources from astrometric catalogs can be extracted from images.
+
+        The following datasets are used in these tests:
+
+            * ACS/SBC dataset with >10 sources (in image and in GAIADR2)
+
+        """
+        self.input_loc = 'catalog_tests'
+        self.curdir = os.getcwd()
+        truth_path = [self.input_repo, self.tree, self.input_loc, *self.ref_loc]
+
+        if not isinstance(input_filenames, list):
+            input_filenames = [input_filenames]
+
+        try:
+            # Make local copies of input files
+            local_files = []
+            for infile in input_filenames:
+                downloaded_files = self.get_input_file(infile, docopy=True)
+                local_files.extend(downloaded_files)
+
+            reference_wcs = amutils.build_reference_wcs(local_files)
+            input_catalog_dict = generate_source_catalogs(local_files[0], reference_wcs)
+            imcat = input_catalog_dict[local_files[0]]['catalog_table']
+            # create FITS WCS corrector object
+            wcs_corrector = tweakwcs.FITSWCS(reference_wcs)
+
+            # get reference catalog as 'truth' files
+            reference_catalog = get_bigdata(*truth_path, truth_file, docopy=True)
+            reference_table = Table.read(reference_catalog)
+            num_expected = len(reference_table)
+
+            # Perform matching
+            match = tweakwcs.TPMatch(searchrad=5, separation=0.1, tolerance=5, use2dhist=True)
+            ridx, iidx = match(reference_table, imcat, wcs_corrector)
+            nmatches = len(ridx)
+
+        except Exception:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
+            sys.exit()
+
+        assert (nmatches > 0.8*num_expected)


### PR DESCRIPTION
This implements the first test of the new source extraction code.  The test uses ACS/SBC data obtained at runtime through astroquery, along with a truth file created 'by hand' for this data.  

This PR includes a number of changes to other code in order to run successfully, including:

- changing API for 'amutils.extract_sources' to use '**pars' instead of explicitly named parameters
- adding new instrument-specific defaults for ACS/SBC data 
- adding logic in 'amutils.classify_sources' to protect against spurious(?) source detections  
- changing column name for sky coordinates to 'RA' and 'DEC' (from 'ra'/'dec') to be compatible with tweakwcs.