### PR TITLE
Source detection with daostarfind

### DIFF
--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -45,7 +45,7 @@ detector_specific_params = {"acs":
                                  "sbc":
                                      {"fwhmpsf": 0.065,
                                       "classify": False,
-                                      "threshold": 10},
+                                      "threshold": 2.0},
                                  "wfc":
                                      {"fwhmpsf": 0.076,
                                       "classify": True,
@@ -245,7 +245,7 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
             print("-------------------- STEP 6: Cross matching and fitting --------------------")
             # Specify matching algorithm to use
             match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
-                                     tolerance=100, use2dhist=False)
+                                     tolerance=5, use2dhist=True)
             # Align images and correct WCS
             tweakwcs.tweak_image_wcs(imglist, reference_catalog, match=match)
             # Interpret RMS values from tweakwcs
@@ -383,9 +383,9 @@ def generate_source_catalogs(imglist, **pars):
         if instrument in detector_specific_params.keys():
             if detector in detector_specific_params[instrument].keys():
                 detector_pars = detector_specific_params[instrument][detector]
-                sourcecatalogdict[imgname]["params"] = detector_pars
                 # to allow generate_source_catalog to get detector specific parameters
-                pars.update(detector_pars)
+                detector_pars.update(pars)
+                sourcecatalogdict[imgname]["params"] = detector_pars
             else:
                 sys.exit("ERROR! Unrecognized detector '{}'. Exiting...".format(detector))
         else:
@@ -394,7 +394,8 @@ def generate_source_catalogs(imglist, **pars):
         # Identify sources in image, convert coords from chip x, y form to reference WCS sky RA, Dec form.
         imgwcs = HSTWCS(imghdu, 1)
         fwhmpsf_pix = sourcecatalogdict[imgname]["params"]['fwhmpsf']/imgwcs.pscale #Convert fwhmpsf from arsec to pixels
-        sourcecatalogdict[imgname]["catalog_table"] = amutils.generate_source_catalog(imghdu, fwhm=fwhmpsf_pix, **pars)
+
+        sourcecatalogdict[imgname]["catalog_table"] = amutils.generate_source_catalog(imghdu, fwhm=fwhmpsf_pix, **detector_pars)
 
         # write out coord lists to files for diagnostic purposes. Protip: To display the sources in these files in DS9,
         # set the "Coordinate System" option to "Physical" when loading the region file.

--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -223,7 +223,7 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
         # 5: Extract catalog of observable sources from each input image
             print("-------------------- STEP 5: Source finding --------------------")
             if not extracted_sources:
-                extracted_sources = generate_source_catalogs(processList, centering_mode='starfind')
+                extracted_sources = generate_source_catalogs(processList, centering_mode='starfind', nlargest=100)
                 for imgname in extracted_sources.keys():
                     table=extracted_sources[imgname]["catalog_table"]
                     # The catalog of observable sources must have at least MIN_OBSERVABLE_THRESHOLD entries to be useful
@@ -244,15 +244,27 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
         # 6: Cross-match source catalog with astrometric reference source catalog, Perform fit between source catalog and reference catalog
             print("-------------------- STEP 6: Cross matching and fitting --------------------")
             # Specify matching algorithm to use
-            match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
-                                     tolerance=20, use2dhist=True)
+            match = tweakwcs.TPMatch(searchrad=75, separation=0.1,
+                                     tolerance=2, use2dhist=True)
             # Align images and correct WCS
             tweakwcs.tweak_image_wcs(imglist, reference_catalog, match=match)
             # Interpret RMS values from tweakwcs
             interpret_fit_rms(imglist, reference_catalog)
-
             tweakwcs_info_keys = OrderedDict(imglist[0].meta['tweakwcs_info']).keys()
-            imgctr=0
+
+            imgctr = 0
+            for item in imglist:
+                print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FIT PARAMETERS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+                if item.meta['chip'] == 1:
+                    image_name = processList[imgctr]
+                    imgctr += 1
+                print("image: {}".format(image_name))
+                print("chip: {}".format(item.meta['chip']))
+                print("group_id: {}".format(item.meta['group_id']))
+                for tweakwcs_info_key in tweakwcs_info_keys:
+                    if not tweakwcs_info_key.startswith("matched"):
+                        print("{} : {}".format(tweakwcs_info_key,item.meta['tweakwcs_info'][tweakwcs_info_key]))                
+
             for item in imglist:
                 retry_fit = False
                 #Handle fitting failures (no matches found)
@@ -269,16 +281,6 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
                 max_rms_val = item.meta['tweakwcs_info']['TOTAL_RMS']
                 num_xmatches = item.meta['tweakwcs_info']['nmatches']
                 # print fit params to screen
-                print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FIT PARAMETERS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-                if item.meta['chip'] == 1:
-                    image_name = processList[imgctr]
-                    imgctr += 1
-                print("image: {}".format(image_name))
-                print("chip: {}".format(item.meta['chip']))
-                print("group_id: {}".format(item.meta['group_id']))
-                for tweakwcs_info_key in tweakwcs_info_keys:
-                    if not tweakwcs_info_key.startswith("matched"):
-                        print("{} : {}".format(tweakwcs_info_key,item.meta['tweakwcs_info'][tweakwcs_info_key]))
                 # print("Radial shift: {}".format(math.sqrt(item.meta['tweakwcs_info']['shift'][0]**2+item.meta['tweakwcs_info']['shift'][1]**2)))
                 print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
 
@@ -294,7 +296,7 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
                         return(1)
                 elif max_rms_val > MAX_FIT_RMS:
                     if catalogIndex < numCatalogs-1:
-                        print("Fit RMS value = {}mas greater than the maximum threshold value {}.".format(item.meta['tweakwcs_info']['FIT_RMS'].value,MAX_FIT_RMS))
+                        print("Fit RMS value = {}mas greater than the maximum threshold value {}.".format(item.meta['tweakwcs_info']['TOTAL_RMS'],MAX_FIT_RMS))
                         print("Try again with the next catalog")
                         catalogIndex += 1
                         retry_fit = True
@@ -481,12 +483,12 @@ def interpret_fit_rms(tweakwcs_output, reference_catalog):
     group_dict = {'avg_RMS':None}
     obs_rms = []
     for group_id in group_ids:
-        group_dict[group_id] = {'ref_idx':None, 'FIT_RMS':None}
         for item in tweakwcs_output:
             if item.meta['tweakwcs_info']['status'].startswith('FAILED'):
                 continue
             if item.meta['group_id'] == group_id and \
-               group_dict[group_id]['ref_idx'] is None:
+               group_id not in group_dict:
+                    group_dict[group_id] = {'ref_idx':None, 'FIT_RMS':None}
                     tinfo = item.meta['tweakwcs_info']
                     ref_idx = tinfo['fit_ref_idx']
                     group_dict[group_id]['ref_idx'] = ref_idx
@@ -500,6 +502,7 @@ def interpret_fit_rms(tweakwcs_output, reference_catalog):
                     obs_rms.append(fit_rms.value)
     # Compute RMS for entire ASN/observation set
     total_rms = np.mean(obs_rms)
+    #total_rms = np.sqrt(np.sum(np.array(obs_rms)**2))
 
     # Now, append computed results to tweakwcs_output
     for item in tweakwcs_output:

--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -507,7 +507,11 @@ def interpret_fit_rms(tweakwcs_output, reference_catalog):
     # Now, append computed results to tweakwcs_output
     for item in tweakwcs_output:
         group_id = item.meta['group_id']
-        item.meta['tweakwcs_info']['FIT_RMS'] = group_dict[group_id]['FIT_RMS']
+        if group_id in group_dict:
+            fit_rms = group_dict[group_id]['FIT_RMS']
+        else:
+            fit_rms = None
+        item.meta['tweakwcs_info']['FIT_RMS'] = fit_rms
         item.meta['tweakwcs_info']['TOTAL_RMS'] = total_rms
         item.meta['tweakwcs_info']['NUM_FITS'] = len(group_ids)
 

--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -223,7 +223,7 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
         # 5: Extract catalog of observable sources from each input image
             print("-------------------- STEP 5: Source finding --------------------")
             if not extracted_sources:
-                extracted_sources = generate_source_catalogs(processList, centering_mode='segmentation')
+                extracted_sources = generate_source_catalogs(processList, centering_mode='starfind')
                 for imgname in extracted_sources.keys():
                     table=extracted_sources[imgname]["catalog_table"]
                     # The catalog of observable sources must have at least MIN_OBSERVABLE_THRESHOLD entries to be useful
@@ -245,7 +245,7 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
             print("-------------------- STEP 6: Cross matching and fitting --------------------")
             # Specify matching algorithm to use
             match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
-                                     tolerance=5, use2dhist=True)
+                                     tolerance=20, use2dhist=True)
             # Align images and correct WCS
             tweakwcs.tweak_image_wcs(imglist, reference_catalog, match=match)
             # Interpret RMS values from tweakwcs
@@ -415,7 +415,7 @@ def generate_source_catalogs(imglist, **pars):
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-def update_image_wcs_info(tweakwcs_output, imagelist):
+def update_image_wcs_info(tweakwcs_output,imagelist):
     """Write newly computed WCS information to image headers
 
     Parameters

--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -47,7 +47,7 @@ detector_specific_params = {"acs":
                                       "classify": False,
                                       "threshold": 2.0},
                                  "wfc":
-                                     {"fwhmpsf": 0.076,
+                                     {"fwhmpsf": 0.13, #0.076,
                                       "classify": True,
                                       "threshold": -1.1}},
                             "wfc3":
@@ -223,7 +223,7 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
         # 5: Extract catalog of observable sources from each input image
             print("-------------------- STEP 5: Source finding --------------------")
             if not extracted_sources:
-                extracted_sources = generate_source_catalogs(processList)
+                extracted_sources = generate_source_catalogs(processList, centering_mode='segmentation')
                 for imgname in extracted_sources.keys():
                     table=extracted_sources[imgname]["catalog_table"]
                     # The catalog of observable sources must have at least MIN_OBSERVABLE_THRESHOLD entries to be useful

--- a/hlapipeline/utils/astrometric_utils.py
+++ b/hlapipeline/utils/astrometric_utils.py
@@ -410,6 +410,8 @@ def extract_sources(img, **pars):
             threshold = default_threshold
     else:
         bkg_rms_mean = 3. * threshold
+    if bkg_rms_mean < 0:
+        bkg_rms_mean = 0.
     sigma = fwhm * gaussian_fwhm_to_sigma
     kernel = Gaussian2DKernel(sigma, x_size=source_box, y_size=source_box)
     kernel.normalize()
@@ -437,17 +439,19 @@ def extract_sources(img, **pars):
         # Identify nbrightest/largest sources 
         if nlargest is not None:
             large_labels = np.flip(np.argsort(segm.areas)+1)[:nlargest]
-
-        print("Looking for sources in {} segments".format(len(segm.labels))) 
+        print("Looking for sources in {} segments".format(len(segm.labels)))
+        
         for label in segm.labels:
             if nlargest is not None and label not in large_labels:
                 continue # Move on to the next segment
             # Create mask which is blank everywhere except in the segment
             blank_segm = np.zeros(segm.shape, dtype=np.bool)
             blank_segm[np.where(segm.data==label)] = 1
+
             # apply mask to original image
             detection_img = img*blank_segm
-            # Detect sources in this specific segment
+
+            # Detect sources in this specific segment            
             seg_table = daofind(detection_img)
                 
             # Pick out brightest source only

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -45,7 +45,7 @@ class TestPipeline(BaseHLATest):
                                  ('J8D806010','j8d806bgq_sky_cat.ecsv'),
                                  ('IB2V09010', 'ib2v09kzq_sky_cat.ecsv')]
                             )
-    def XXtest_generate_catalog(self,input_filenames, truth_file):
+    def test_generate_catalog(self,input_filenames, truth_file):
         """ Verify whether sources from astrometric catalogs can be extracted from images.
 
         Success Criteria
@@ -140,7 +140,7 @@ class TestPipeline(BaseHLATest):
             for group_id,image in enumerate(local_files):
                 imglist.extend(amutils.build_nddata(image, group_id,
                                                     source_catalogs[image]['catalog_table']))
-                                                
+
             # Specify matching algorithm to use
             match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
                                      tolerance=5, use2dhist=True)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -8,7 +8,7 @@ from astropy.io import fits
 import tweakwcs
 from base_test import BaseHLATest
 import hlapipeline.utils.astrometric_utils as amutils
-from hlapipeline.alignimages import generate_source_catalogs, detector_specific_params
+from hlapipeline.alignimages import generate_source_catalogs
 from ci_watson.artifactory_helpers import get_bigdata
 
 
@@ -45,7 +45,7 @@ class TestPipeline(BaseHLATest):
                                  ('J8D806010','j8d806bgq_sky_cat.ecsv'),
                                  ('IB2V09010', 'ib2v09kzq_sky_cat.ecsv')]
                             )
-    def test_generate_catalog(self,input_filenames, truth_file):
+    def XXtest_generate_catalog(self,input_filenames, truth_file):
         """ Verify whether sources from astrometric catalogs can be extracted from images.
 
         Success Criteria
@@ -66,15 +66,10 @@ class TestPipeline(BaseHLATest):
             for infile in input_filenames:
                 downloaded_files = self.get_input_file(infile, docopy=True)
                 local_files.extend(downloaded_files)
-            
-            test_image = local_files[0]
-            print("Testing with {}".format(test_image))
-            imghdu = fits.open(test_image)
-            instrume = imghdu[0].header['instrume'].lower()
-            detector = imghdu[0].header['detector'].lower()
-            instr_pars = detector_specific_params[instrume][detector]
+
             reference_wcs = amutils.build_reference_wcs(local_files)
-            imcat = amutils.generate_sky_catalog(imghdu, reference_wcs, **instr_pars)
+            input_catalog_dict = generate_source_catalogs([local_files[0]], reference_wcs)
+            imcat = input_catalog_dict[local_files[0]]['catalog_table']
             imcat.rename_column('xcentroid', 'x')
             imcat.rename_column('ycentroid', 'y')
 
@@ -91,7 +86,7 @@ class TestPipeline(BaseHLATest):
             num_expected = len(reference_table)
 
             # Perform matching
-            match = tweakwcs.TPMatch(searchrad=200, separation=0.1, tolerance=5, use2dhist=True)
+            match = tweakwcs.TPMatch(searchrad=5, separation=0.1, tolerance=5, use2dhist=True)
             ridx, iidx = match(reference_table, imcat, wcs_corrector)
             nmatches = len(ridx)
 
@@ -101,6 +96,7 @@ class TestPipeline(BaseHLATest):
             sys.exit()
 
         assert (nmatches > 0.8*num_expected)
+
 
     @pytest.mark.parametrize("input_filenames",
                                 [('j8ep04lwq')]
@@ -124,18 +120,19 @@ class TestPipeline(BaseHLATest):
             input_filenames = [input_filenames]
 
         # Use this to collect all failures BEFORE throwing AssertionError
-        failures=False  
+        failures=False
         try:
             # Make local copies of input files
             local_files = []
             for infile in input_filenames:
                 downloaded_files = self.get_input_file(infile, docopy=True)
                 local_files.extend(downloaded_files)
+
             # generate reference catalog
             refcat = amutils.create_astrometric_catalog(local_files, catalog='GAIADR2')
 
             # Generate source catalogs for each input image
-            source_catalogs = generate_source_catalogs(local_files, None)
+            source_catalogs = generate_source_catalogs(local_files)
 
             # Convert input images to tweakwcs-compatible NDData objects and
             # attach source catalogs to them.
@@ -143,13 +140,19 @@ class TestPipeline(BaseHLATest):
             for group_id,image in enumerate(local_files):
                 imglist.extend(amutils.build_nddata(image, group_id,
                                                     source_catalogs[image]['catalog_table']))
-
+                                                
             # Specify matching algorithm to use
-            match = tweakwcs.TPMatch(searchrad=250, separation=0.1, 
+            match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
                                      tolerance=5, use2dhist=True)
 
             # Align images and correct WCS
             tweakwcs.tweak_image_wcs(imglist, refcat, match=match)
+            for chip in imglist:
+                status = chip.meta['tweakwcs_info']['status']
+                if status.startswith('FAIL'):
+                    failures = True
+                    print("STATUS for {}: {}".format(chip.meta['filename'], status))
+                    break
         except Exception:
             failures = True
             print("ALIGNMENT EXCEPTION:  Failed to align {}".format(infile))
@@ -158,6 +161,7 @@ class TestPipeline(BaseHLATest):
             for chip in imglist:
                 tweak_info = chip.meta.get('tweakwcs_info', None)
                 chip_id = chip.meta.get('chip_id',1)
+
                 # determine 30mas limit in pixels
                 xylimit = 30
                 # Perform comparisons
@@ -171,6 +175,5 @@ class TestPipeline(BaseHLATest):
                     msg2 = "    RMS=({:.4f},{:.4f})mas [limit:{:.4f}mas] and NMATCHES={}"
                     print(msg1.format(infile, chip_id))
                     print(msg2.format(xrms, yrms, xylimit, nmatches))
-            
+
         assert(not failures)
-    


### PR DESCRIPTION
This set of changes attempts to replace the segmentation-based centering with a more precise centering algorithm based on DAOStarFinder.  In addition, a couple of other changes were included; namely,

- Default threshold for ACS/SBC data was found to be more useful at a lower value (2.0 instead of 10.0)
- FWHMPSF value for ACS/WFC is actually (based on the ACS Instrument Handbook) 0.13, not 0.075, and this new value was shown to improve the accuracy of the positions as well
- the parameter 'use2dhist' was turned on as it should be more useful with the new more accurate/consistent source positions

A new parameter was added to the interface for 'extract_sources' to allow the calling routine to ask for results with either the old segmentation code or the newer starfind centering code.  This would allow the calling code to use whatever is found to produce the most useful catalog based on the sources in the field of view, with fields containing nearly all extended sources possibly benefiting from the original code.