### PR TITLE
Fix import error in test_hlapipeline

### DIFF
--- a/tests/test_hlapipeline.py
+++ b/tests/test_hlapipeline.py
@@ -7,7 +7,6 @@ import pytest
 
 from click.testing import CliRunner
 
-from hlapipeline import hlapipeline
 from hlapipeline import cli
 
 


### PR DESCRIPTION
Simplest possible change to the test_hlapipeline test originally created by the astropy_helpers tools used to create this package in the first place.  This should no longer cause problems when our tests pass for each PR.