### PR TITLE
Make starfind algorithm 4-5 times faster

### DIFF
--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -36,6 +36,7 @@ MIN_CROSS_MATCHES = 3
 MIN_FIT_MATCHES = 6
 MAX_FIT_RMS = 10 # RMS now in mas, 1.0
 MAX_FIT_LIMIT = 1000 # Maximum RMS that a result is useful
+MAX_SOURCES_PER_CHIP = 250  # Maximum number of sources per chip to include in source catalog
 
 # Module-level dictionary contains instrument/detector-specific parameters used later on in the script.
 detector_specific_params = {"acs":
@@ -200,7 +201,9 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
 
     # 4: Extract catalog of observable sources from each input image
     print("-------------------- STEP 4: Source finding --------------------")
-    extracted_sources = generate_source_catalogs(processList, centering_mode='starfind', nlargest=100)
+    extracted_sources = generate_source_catalogs(processList,
+                                                 centering_mode='starfind',
+                                                 nlargest=MAX_SOURCES_PER_CHIP)
 
     for imgname in extracted_sources.keys():
         table=extracted_sources[imgname]["catalog_table"]


### PR DESCRIPTION
These changes do NOT alter the results of the source finding; they only allow the entire alignment process to run 4-5 times faster than the original starfind implementation from #43 .  This update was based on discussions with Larry on how to better use the photutils-generated products.

In addition, the originally hard-coded parameter limiting the number of sources measured per chip (for speed) has been increased from 100 to 250 per chip while also converting it to a module level variable MAX_SOURCES_PER_CHIP.  This will allow dense fields to use more of the sources to obtain alignment and a good fit, while (typically) resulting in a more accurate solution.  