### PR TITLE
Only update table upon successful fit

### DIFF
--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -199,6 +199,7 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
     # for alignment purposes.  For filtered data, 'doProcess=0' and 'status=9999' in the table.
     if filteredTable['doProcess'].sum() == 0:
         print("No viable images in filtered table - no processing done.\n")
+        filteredTable[index]['status'] = 1
         return(filteredTable)
 
     # Get the list of all "good" files to use for the alignment
@@ -313,6 +314,7 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
         # update to the meta information with the lowest rms if it is reasonable
         for item in imglist:
             item.meta = item.best_meta
+        filteredTable['status'][:] = 0
 
     info_keys = OrderedDict(imglist[0].meta['tweakwcs_info']).keys()
     # Update filtered table with number of matched sources and other information
@@ -348,7 +350,6 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
     deltaDT = (currentDT - startingDT).total_seconds()
     print('Processing time of [STEP 7]: {} sec'.format(deltaDT))
     startingDT = currentDT
-    filteredTable['status'][:] = 0
     return (filteredTable)
 
 def match_default_fit(imglist, reference_catalog, print_fit_parameters=True):

--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -298,6 +298,22 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
                         item.best_meta = item.meta.copy()
                 imglist_temp = imglist.copy() # preserve best fit solution so that it can be inserted into a reinitialized imglist next time through.
 
+    currentDT = datetime.datetime.now()
+    deltaDT = (currentDT - startingDT).total_seconds()
+    print('Processing time of [STEP 5b]: {} sec'.format(deltaDT))
+    startingDT = currentDT
+    # 7: Write new fit solution to input image headers
+    print("-------------------- STEP 7: Update image headers with new WCS information --------------------")
+    if best_fit_rms > 0 and best_fit_rms < MAX_FIT_RMS:
+        print("The fitting process was successful with a best fit total rms of {} mas".format(best_fit_rms))
+    else:
+        print("The fitting process was unsuccessful with a best fit total rms of {} mas".format(best_fit_rms))
+
+    if best_fit_rms > 0 and best_fit_rms < MAX_FIT_LIMIT:
+        # update to the meta information with the lowest rms if it is reasonable
+        for item in imglist:
+            item.meta = item.best_meta
+
     info_keys = OrderedDict(imglist[0].meta['tweakwcs_info']).keys()
     # Update filtered table with number of matched sources and other information
     for item in imglist:
@@ -320,26 +336,9 @@ def perform_align(input_list, archive=False, clobber=False, update_hdr_wcs=False
             filteredTable[index]['total_rms'] = item.meta['tweakwcs_info']['TOTAL_RMS']
             filteredTable.pprint(max_width=-1)
 
-    currentDT = datetime.datetime.now()
-    deltaDT = (currentDT - startingDT).total_seconds()
-    print('Processing time of [STEP 5b]: {} sec'.format(deltaDT))
-    startingDT = currentDT
     # 7: Write new fit solution to input image headers
     print("-------------------- STEP 7: Update image headers with new WCS information --------------------")
-    if best_fit_rms < MAX_FIT_RMS:
-       print("The fitting process was successful with a best fit total rms of {} mas".format(best_fit_rms))
-    else:
-       print("The fitting process was unsuccessful with a best fit total rms of {} mas".format(best_fit_rms))
-
-    if best_fit_rms < MAX_FIT_LIMIT:
-        # update to the meta information with the lowest rms if it is reasonable
-        for item in imglist:
-            item.meta = item.best_meta
-
-
-    # 7: Write new fit solution to input image headers
-    print("-------------------- STEP 7: Update image headers with new WCS information --------------------")
-    if update_hdr_wcs:
+    if best_fit_rms > 0 and update_hdr_wcs:
         update_image_wcs_info(imglist, processList)
         print("\nSUCCESS")
     else:


### PR DESCRIPTION
The logic for updating the table needed to be modified to only populate the table with values upon actually performing a fit.  This allows datasets with NO sources (like J8KB05030) to process, and quit gracefully without signifying a success.  

This change also has the added benefit of updating the table with the actual best fit, whereas before it was updating with the last fit recorded in `.meta` (I think), not what was copied to `.best_meta`.  

The logic was modified to recognize when no fit was performed by checking if `best_fit_rms > 0` as well as less than various limits.  

Finally, only when `best_fit_rms > 0` will headers get updated in this version.  