### PR TITLE
Added Pytest decorator, skip, to tests with many datasets for now.

### DIFF
--- a/tests/test_bigRandom.py
+++ b/tests/test_bigRandom.py
@@ -39,8 +39,7 @@ class TestRandomAlignMosaic(BaseHLATest):
 
     ref_loc = ['truth']
 
-    #@pytest.mark.xfail
-    #@pytest.mark.slow
+    @pytest.mark.skip
     def test_random_align(self):
         """ Wrapper to set up the test for aligning a large number of randomly
             selected fields (aka datasets) from a input ascii file (CSV)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -36,8 +36,7 @@ class TestRandomAlignMosaic(BaseHLATest):
 
     ref_loc = ['truth']
 
-    #@pytest.mark.xfail
-    #@pytest.mark.slow
+    @pytest.mark.skip
     def test_random_align(self):
         """ Wrapper to set up the test for aligning a large number of randomly
             selected fields (aka datasets) from a input ascii file (CSV)


### PR DESCRIPTION
Force the hlapipeline tests which process hundreds of datasets to be skip.  These tests are thus far run manually on the desktop.