### PR TITLE
No trace computing

### DIFF
--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -166,8 +166,9 @@ def perform_align(input_list, archive=False, clobber=False, debug=True, update_h
         Display git repository information?
 
     output : Boolean
-        Should utils.astrometric_utils.create_astrometric_catalog() generate file "ref_cat.ecsv" and should
-        generate_source_catalogs() generate the .reg region files for every chip of every input image?
+        Should utils.astrometric_utils.create_astrometric_catalog() generate file 'ref_cat.ecsv' and should
+        generate_source_catalogs() generate the .reg region files for every chip of every input image and should
+        generate_astrometric_catalog() generate file 'refcatalog.cat'?
 
     Returns
     -------
@@ -735,8 +736,8 @@ def generate_astrometric_catalog(imglist, **pars):
         pars['output'] = None
     out_catalog = amutils.create_astrometric_catalog(imglist,**pars)
     pars = temp_pars.copy()
-    # if the catalog has contents, write the catalog to ascii text file
-    if len(out_catalog) > 0:
+    #if the catalog has contents, write the catalog to ascii text file
+    if len(out_catalog) > 0 and pars['output']:
         catalog_filename = "refcatalog.cat"
         out_catalog.write(catalog_filename, format="ascii.fast_commented_header")
         print("Wrote reference catalog {}.".format(catalog_filename))
@@ -1035,8 +1036,10 @@ if __name__ == '__main__':
 
     PARSER.add_argument( '-o', '--output', required=False,choices=['True','False'],default='False',help='Should '
                     'utils.astrometric_utils.create_astrometric_catalog() generate file "ref_cat.ecsv" and should '
-                    'generate_source_catalogs() generate the .reg region files for every chip of every input image? '
-                    'Unless explicitly set, the default is "False".')
+                    'generate_source_catalogs() generate the .reg region files for every chip of every input image and '
+                    'should generate_astrometric_catalog() generate file "refcatalog.cat"? Unless explicitly set, the '
+                    'default is "False".')
+    'Should the code generate '
 
     ARGS = PARSER.parse_args()
 

--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -136,8 +136,8 @@ def convert_string_tf_to_boolean(invalue):
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-def perform_align(input_list, archive=False, clobber=False, debug = True, update_hdr_wcs=False,
-                  print_fit_parameters=True, print_git_info=True, output=True):
+def perform_align(input_list, archive=False, clobber=False, debug=True, update_hdr_wcs=False,
+                  print_fit_parameters=True, print_git_info=False, output=True): # TODO: set 'debug' and 'output' back to 'False' before release.
     """Main calling function.
 
     Parameters
@@ -1025,6 +1025,19 @@ if __name__ == '__main__':
     PARSER.add_argument( '-u', '--update_hdr_wcs', required=False,choices=['True','False'],default='False',help='Write '
                     'newly computed WCS information to image image headers and create headerlet files? Unless explicitly '
                     'set, the default is "False".')
+
+    PARSER.add_argument( '-p', '--print_fit_parameters', required=False,choices=['True','False'],default='True',help=''
+                    'Specify whether or not to print out FIT results for each chip. Unless explicitly set, the default '
+                    'is "True".')
+
+    PARSER.add_argument( '-g', '--print_git_info', required=False,choices=['True','False'],default='False',help='Display '
+                    'git repository information? Unless explicitly set, the default is "False".')
+
+    PARSER.add_argument( '-o', '--output', required=False,choices=['True','False'],default='False',help='Should '
+                    'utils.astrometric_utils.create_astrometric_catalog() generate file "ref_cat.ecsv" and should '
+                    'generate_source_catalogs() generate the .reg region files for every chip of every input image? '
+                    'Unless explicitly set, the default is "False".')
+
     ARGS = PARSER.parse_args()
 
     # Build list of input images
@@ -1038,6 +1051,7 @@ if __name__ == '__main__':
         else:
             input_list.append(item)
 
+    # Convert input args from text strings to Boolean True/False values
     archive = convert_string_tf_to_boolean(ARGS.archive)
 
     clobber = convert_string_tf_to_boolean(ARGS.clobber)
@@ -1046,7 +1060,13 @@ if __name__ == '__main__':
 
     update_hdr_wcs = convert_string_tf_to_boolean(ARGS.update_hdr_wcs)
 
+    print_fit_parameters = convert_string_tf_to_boolean(ARGS.print_fit_parameters)
+
+    print_git_info = convert_string_tf_to_boolean(ARGS.print_git_info)
+
+    output = convert_string_tf_to_boolean(ARGS.output)
+
     # Get to it!
-    return_value = perform_align(input_list,archive,clobber,debug,update_hdr_wcs)
+    return_value = perform_align(input_list,archive,clobber,debug,update_hdr_wcs,print_fit_parameters,print_git_info)
 
     print(return_value)

--- a/hlapipeline/alignimages.py
+++ b/hlapipeline/alignimages.py
@@ -166,7 +166,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=True, update_h
         Display git repository information?
 
     output : Boolean
-        Should utils.astrometric_utils.create_astrometric_catalog() genrate file "ref_cat.ecsv" and should
+        Should utils.astrometric_utils.create_astrometric_catalog() generate file "ref_cat.ecsv" and should
         generate_source_catalogs() generate the .reg region files for every chip of every input image?
 
     Returns

--- a/hlapipeline/utils/astrometric_utils.py
+++ b/hlapipeline/utils/astrometric_utils.py
@@ -201,7 +201,7 @@ def create_astrometric_catalog(inputs, **pars):
     # Write out table to a file, if specified
     if output:
         ref_table.write(output, format=table_format)
-    print("Created catalog '{}' with {} sources".format(output, num_sources))
+        print("Created catalog '{}' with {} sources".format(output, num_sources))
 
     return ref_table
 


### PR DESCRIPTION
1) Added new perform_align() input parameter **_output_** that controls whether or not utils.astrometric_utils.create_astrometric_catalog() should generate file "ref_cat.ecsv" and whether or not generate_source_catalogs() should generate the .reg region files.

2) updated the command-line inputs so that they line up with the perform_align() input parameters and input parameter default values in the subroutine definition.